### PR TITLE
custom name for square css rule to account for #48

### DIFF
--- a/styles/_utility.scss
+++ b/styles/_utility.scss
@@ -639,15 +639,15 @@ $text-align-directions: ("left", "center", "right");
     border: 2px solid var(--border-color);
 }
 
-.square {
+.jtcs-square {
     width: 2rem;
     height: 2rem;
 }
-.square-medium {
+.jtcs-square-medium {
     width: 4rem;
     height: 4rem;
 }
-.square-large {
+.jtcs-square-large {
     width: 6rem;
     height: 6rem;
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -942,17 +942,17 @@ button.icon-button.active:hover, button.icon-button.active:focus {
   border: 2px solid var(--border-color);
 }
 
-.square {
+.jtcs-square {
   width: 2rem;
   height: 2rem;
 }
 
-.square-medium {
+.jtcs-square-medium {
   width: 4rem;
   height: 4rem;
 }
 
-.square-large {
+.jtcs-square-large {
   width: 6rem;
   height: 6rem;
 }

--- a/templates/image-controls.hbs
+++ b/templates/image-controls.hbs
@@ -3,8 +3,8 @@
 	<ul class="displayLocations | flex-column gap-small reset-margin reset-padding">
 		{{#each displayMethods as |method|}}
 		<li class="button-container {{method.additionalParentClass}}">
-			<button class="floating-control square {{additionalClass}}" id="{{method.name}}" 
-                data-method="{{method.name}}" 
+			<button class="floating-control jtcs-square {{additionalClass}}" id="{{method.name}}"
+                data-method="{{method.name}}"
                 {{#if (eq method.name "fadeJournal")}}
                    data-action="displayActionButton.click.fadeJournal" 
                {{else if (eq method.name "anyScene")}}


### PR DESCRIPTION
The square rule conflicted with the forien's quest log module. Now it's more unique and doesn't break the quest tracker.

This should fix #48 but the rest of the rules should probably be renamed too some time in the future.

This was the only occurence of the square rule in the module and I don't see anything out of the ordinary when clicking through your module.